### PR TITLE
Expand hash only in case of single arity

### DIFF
--- a/lib/aasm/core/invokers/literal_invoker.rb
+++ b/lib/aasm/core/invokers/literal_invoker.rb
@@ -70,7 +70,7 @@ module AASM
 
         def invoke_with_fixed_arity
           req_args = args[0..(subject_arity - 1)]
-          if req_args[0].is_a?(Hash)
+          if subject_arity == 1 && req_args[0].is_a?(Hash)
             record.__send__(subject, **req_args[0])
           else
             record.__send__(subject, *req_args)


### PR DESCRIPTION
Hey @thiagofm,

I made this pull request to fix the bug that I described here: https://github.com/aasm/aasm/pull/857#discussion_r1983799605

Passes all of the rspec tests, although I couldn't get appraisal working to test with different versions of rails.

Please let me know what you think of this fix.